### PR TITLE
[WIP] Task #5: [GAME] Add combo multiplier to Snake game

### DIFF
--- a/06_snake/scenes/game_ui.gd
+++ b/06_snake/scenes/game_ui.gd
@@ -4,11 +4,21 @@ class_name GameUI
 ## Provides score display, pause menu, and game over screen
 
 @onready var score_label: Label = $ScoreContainer/ScoreLabel
+@onready var combo_label: Label = $ScoreContainer/ComboLabel
 @onready var pause_panel: Panel = $PausePanel
 @onready var game_over_panel: Panel = $GameOverPanel
 @onready var final_score_label: Label = $GameOverPanel/VBox/FinalScoreLabel
 @onready var high_score_label: Label = $GameOverPanel/VBox/HighScoreLabel
 @onready var new_high_label: Label = $GameOverPanel/VBox/NewHighLabel
+
+# Combo colors for visual feedback
+const COMBO_COLORS = [
+	Color(1, 1, 1, 1),        # 1x - White (default)
+	Color(0.5, 1, 0.5, 1),    # 2x - Light green
+	Color(1, 1, 0, 1),        # 3x - Yellow
+	Color(1, 0.5, 0, 1),      # 4x - Orange
+	Color(1, 0.2, 0.2, 1),    # 5x - Red
+]
 
 func _ready() -> void:
 	GameManager.score_changed.connect(_on_score_changed)
@@ -17,6 +27,7 @@ func _ready() -> void:
 	pause_panel.hide()
 	game_over_panel.hide()
 	new_high_label.hide()
+	combo_label.hide()
 
 func _on_score_changed(new_score: int) -> void:
 	score_label.text = str(new_score)
@@ -49,3 +60,22 @@ func _on_restart_pressed() -> void:
 
 func _on_menu_pressed() -> void:
 	GameManager.go_to_menu()
+
+func update_combo(multiplier: int) -> void:
+	if multiplier <= 1:
+		# No active combo or combo is 1x (no bonus)
+		combo_label.hide()
+		return
+
+	# Show and update combo label
+	combo_label.show()
+	combo_label.text = str(multiplier) + "x COMBO!"
+
+	# Apply color based on combo level (index 0 is for 1x, so use multiplier - 1)
+	var color_index = mini(multiplier - 1, COMBO_COLORS.size() - 1)
+	combo_label.modulate = COMBO_COLORS[color_index]
+
+	# Animate the combo label for visual feedback
+	var tween = create_tween()
+	tween.tween_property(combo_label, "scale", Vector2(1.3, 1.3), 0.08)
+	tween.tween_property(combo_label, "scale", Vector2(1.0, 1.0), 0.12)

--- a/06_snake/scenes/game_ui.tscn
+++ b/06_snake/scenes/game_ui.tscn
@@ -33,6 +33,27 @@ text = "0"
 horizontal_alignment = 1
 vertical_alignment = 1
 
+[node name="ComboLabel" type="Label" parent="ScoreContainer"]
+layout_mode = 1
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -100.0
+offset_top = 50.0
+offset_right = 100.0
+offset_bottom = 90.0
+grow_horizontal = 2
+grow_vertical = 2
+pivot_offset = Vector2(100, 20)
+theme_override_colors/font_color = Color(1, 1, 0, 1)
+theme_override_colors/font_shadow_color = Color(0, 0, 0, 0.5)
+theme_override_font_sizes/font_size = 32
+text = "5x COMBO!"
+horizontal_alignment = 1
+vertical_alignment = 1
+
 [node name="PauseButton" type="Button" parent="ScoreContainer"]
 layout_mode = 1
 anchors_preset = 1


### PR DESCRIPTION
## Implementation Summary

I have successfully implemented the combo multiplier system for the Snake game. Here's a summary of the changes made:

## Changes Made

### 1. `06_snake/scenes/game.gd`
- Added combo system constants: `COMBO_WINDOW` (2s), `COMBO_RESET_TIME` (3s), `MAX_COMBO` (5)
- Added combo tracking variables: `combo_count`, `combo_multiplier`, `time_since_last_food`, `combo_active`
- Added reference to `game_ui` for UI updates
- Modified `_process()` to track time since last food and reset combo after 3 seconds of inactivity
- Created `_on_food_eaten()` function that:
  - Increases combo if food eaten within 2 seconds of previous food
  - Caps combo at 5x maximum
  - Adds score multiplied by combo value
  - Updates the UI with current combo status
- Created `_reset_combo()` function to reset all combo state

### 2. `06_snake/scenes/game_ui.gd`
- Added reference to the new `ComboLabel` node
- Added `COMBO_COLORS` array for visual feedback (white→green→yellow→orange→red)
- Added `combo_label.hide()` in `_ready()` to start hidden
- Created `update_combo(multiplier)` function that:
  - Hides label when no active combo (multiplier ≤ 1)
  - Shows and updates combo text (e.g., "3x COMBO!")
  - Applies color based on combo level
  - Animates with a scale pulse effect

### 3. `06_snake/scenes/game_ui.tscn`
- Added new `ComboLabel` node positioned below the score
- Styled with yellow color, 32pt font, and shadow

## Acceptance Criteria Met
- ✅ Combo increases when eating food within 2 seconds
- ✅ Maximum combo multiplier is 5x
- ✅ Combo resets after 3 seconds idle
- ✅ UI shows current combo multiplier (displays "Nx COMBO!" when active)
- ✅ Score is multiplied by combo value
- ✅ Visual feedback with color changes (green→yellow→orange→red as combo increases)

Completed: sábado,  3 de enero de 2026, 18:01:46 CET
total 40
drwxr-xr-x@  5 luis  wheel   160  3 ene.  17:58 _template
drwxr-xr-x@ 23 luis  wheel   736  3 ene.  17:58 .
drwxrwxrwt  56 root  wheel  1792  3 ene.  17:58 ..
-rw-r--r--@  1 luis  wheel    95  3 ene.  17:58 .git
drwxr-xr-x@  3 luis  wheel    96  3 ene.  17:58 .github
drwxr-xr-x@  2 luis  wheel    64  3 ene.  17:58 .lazy-bird
drwxr-xr-x@  6 luis  wheel   192  3 ene.  17:58 01_flappy_clone
drwxr-xr-x@  8 luis  wheel   256  3 ene.  17:58 02_stack_tower
drwxr-xr-x@  6 luis  wheel   192  3 ene.  17:58 03_color_switch
drwxr-xr-x@  6 luis  wheel   192  3 ene.  17:58 04_endless_runner
drwxr-xr-x@  6 luis  wheel   192  3 ene.  17:58 05_2048
drwxr-xr-x@  6 luis  wheel   192  3 ene.  17:58 06_snake
drwxr-xr-x@  6 luis  wheel   192  3 ene.  17:58 07_breakout
drwxr-xr-x@  6 luis  wheel   192  3 ene.  17:58 08_tap_dash
drwxr-xr-x@  6 luis  wheel   192  3 ene.  17:58 09_ball_bounce
drwxr-xr-x@  6 luis  wheel   192  3 ene.  17:58 10_whack_mole
drwxr-xr-x@  6 luis  wheel   192  3 ene.  17:58 11_doodle_jump
drwxr-xr-x@  6 luis  wheel   192  3 ene.  17:58 12_pong
drwxr-xr-x@  6 luis  wheel   192  3 ene.  17:58 13_memory_match
drwxr-xr-x@  6 luis  wheel   192  3 ene.  17:58 14_fruit_slice
drwxr-xr-x@  6 luis  wheel   192  3 ene.  17:58 15_tetris
-rw-r--r--@  1 luis  wheel  6897  3 ene.  17:58 generate_projects.py
-rw-r--r--@  1 luis  wheel  4269  3 ene.  17:58 README.md
 M 06_snake/scenes/game.gd
 M 06_snake/scenes/game_ui.gd
 M 06_snake/scenes/game_ui.tscn


### Files Changed

```
M	06_snake/scenes/game.gd
M	06_snake/scenes/game_ui.gd
M	06_snake/scenes/game_ui.tscn
```

---

🔄 **Status:** Running tests... (Attempt 1/4)

📋 **Task:** #5
🌿 **Branch:** `feature-casual-games-5`

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>